### PR TITLE
Initial Linear implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ w = {"params": {
     "w[0,0] 2x0e,3x0e": jnp.arange(6, dtype=jnp.float32).reshape(2, 3),
     "w[1,1] 2x1o,3x1o": jnp.arange(6, dtype=jnp.float32).reshape(2, 3),
 }}
-output = linear.apply(w, x)
+output = linear.apply(w, input3)
 print("output", output)
 ```
 

--- a/e3nn.h
+++ b/e3nn.h
@@ -34,4 +34,9 @@ void tensor_product_v3(const char* irrep_str1, const float* data1, const char* i
 // Real spherical harmonics Y_lm(r) of vector (x, y, z) written to out
 void spherical_harmonics(const char* irrep_str, const float x, const float y, const float z, float* out);
 
+// Linear or self-interaction operation
+// it is assumed that weights are raveled into a single float*, stored in the order they appear in irreps_in
+// does not support unsimplified irreps
+void linear(const char* irreps_in, const float* input, const float* weight, const char* irreps_out, float* out);
+
 #endif // ifndef INCLUDED_E3NN_H

--- a/example.c
+++ b/example.c
@@ -5,11 +5,9 @@
 int main(void){
 
     // tensor product
-
     float input1[] = { 0, 1, 2, 3, 4 };
-    float input2[] = { 0, 1, 2, 3, 4, 5};
+    float input2[] = { 0, 1, 2, 3, 4, 5 };
     float product[30] = { 0 };
-
     tensor_product("2x0e + 1x1o", input1, 
                    "1x0o + 1x2o", input2, 
                    "2x0o + 2x1e + 1x2e + 2x2o + 1x3e", product);
@@ -17,12 +15,19 @@ int main(void){
     printf("product ["); for (int i = 0; i < 30; i++){ printf("%.2f, ", product[i]); } printf("]\n");
 
     // spherical harmonics
-
     float sph[9] = { 0 };
-
     spherical_harmonics("1x0e + 1x1o + 1x2e", 1.0, 2.0, 3.0, sph);
 
     printf("sph ["); for (int i = 0; i < 9; i++) { printf("%.2f, ", sph[i]); } printf("]\n");
+
+    // linear/self-interaction
+    float input3[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+    float weight[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5 };
+    float output[12] = { 0 };
+    linear("2x0e + 2x1o", input3, weight,
+           "3x0e + 3x1o", output);
+
+    printf("output ["); for (int i = 0; i < 12; i++) { printf("%.2f, ", output[i]); } printf("]\n");
     
     return 0;
 }


### PR DESCRIPTION
First pass at linear operation (see `linear()` in `e3nn.c`). Assumes `weight` is a buffer of flattened weight matrices, applied in order of the input irreps. E.g.:

```c
float input[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
//                [  2 x 3 weight  ][  2 x 3 weight  ]
float weight[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5 };
float output[12] = { 0 };
linear("2x0e + 2x1o", input, weight,
       "3x0e + 3x1o", output);

printf("output ["); for (int i = 0; i < 12; i++) { printf("%.2f, ", output[i]); } printf("]\n");
```

Would translate to the following jax code:

```python
import jax.numpy as jnp
import e3nn_jax as e3nn
input = e3nn.IrrepsArray("2x0e + 2x1o", jnp.arange(8))
linear = e3nn.flax.Linear(
    irreps_in="2x0e + 2x1o",
    irreps_out="3x0e + 3x1o",
)
w = {"params": {
    "w[0,0] 2x0e,3x0e": jnp.arange(6, dtype=jnp.float32).reshape(2, 3),
    "w[1,1] 2x1o,3x1o": jnp.arange(6, dtype=jnp.float32).reshape(2, 3),
}}
output = linear.apply(w, input)
print("output", output)
```

The inner loop is basically a vanilla matmul and can certainly be optimized, but will worry about timing/optimization later. @mitkotak feel free to review if you'd like as you mentioned in your last PR, but no pressure! 

