### PR TITLE
Use structs for Irreps for all functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,33 +19,46 @@ Currently the only operations implemented are the tensor product, and spherical 
 int main(void){
 
     // tensor product
+    Irreps* irreps1 = irreps_create("2x0e + 1x1o");
     float input1[] = { 0, 1, 2, 3, 4 };
+    Irreps* irreps2 = irreps_create("1x0o + 1x2o");
     float input2[] = { 0, 1, 2, 3, 4, 5 };
+    Irreps* irreps_product = irreps_create("2x0o + 2x1e + 1x2e + 2x2o + 1x3e");
     float product[30] = { 0 };
-    tensor_product("2x0e + 1x1o", input1, 
-                   "1x0o + 1x2o", input2, 
-                   "2x0o + 2x1e + 1x2e + 2x2o + 1x3e", product);
+    tensor_product(irreps1, input1, 
+                   irreps2, input2, 
+                   irreps_product, product);
 
     printf("product ["); for (int i = 0; i < 30; i++){ printf("%.2f, ", product[i]); } printf("]\n");
+    irreps_free(irreps1);
+    irreps_free(irreps2);
+    irreps_free(irreps_product);
+
 
     // spherical harmonics
+    Irreps* irreps_sph = irreps_create("1x0e + 1x1o + 1x2e");
     float sph[9] = { 0 };
-    spherical_harmonics("1x0e + 1x1o + 1x2e", 1.0, 2.0, 3.0, sph);
+    spherical_harmonics(irreps_sph, 1.0, 2.0, 3.0, sph);
 
     printf("sph ["); for (int i = 0; i < 9; i++) { printf("%.2f, ", sph[i]); } printf("]\n");
+    irreps_free(irreps_sph);
+
 
     // linear/self-interaction
+    Irreps* irreps3 = irreps_create("2x0e + 2x1o");
     float input3[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
     //                 [  2 x 3 weight  ][  2 x 3 weight  ]
     float weight[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5 };
+    Irreps* irreps_output = irreps_create("3x0e + 3x1o");
     float output[12] = { 0 };
-    linear("2x0e + 2x1o", input3, weight,
-           "3x0e + 3x1o", output);
+    linear(irreps3, input3, weight,
+           irreps_output, output);
 
     printf("output ["); for (int i = 0; i < 12; i++) { printf("%.2f, ", output[i]); } printf("]\n");
-    
+    irreps_free(irreps3);
+    irreps_free(irreps_output);
+
     return 0;
-}
 ```
 
 ```shell

--- a/e3nn.h
+++ b/e3nn.h
@@ -13,30 +13,41 @@ typedef struct {
     int p; // parity
 } Irrep;
 
+typedef struct {
+    Irrep* irreps;
+    int size;
+} Irreps;
 
-// parse e3nn string into array of Irrep of length size
-Irrep* parse_irrep_str(const char* str, int* size);
+
+// create Irreps struct from string
+Irreps* irreps_create(const char* str);
+
+// free Irreps struct
+void irreps_free(Irreps* irreps);
+
+// dimension of irreps
+int irreps_dim(const Irreps* irreps);
 
 // tensor product between data1 and data2, written to datao, with respective
 // representation strings irrep_str1, irrep_str2, irrep_stro
-void tensor_product_v1(const char* irrep_str1, float* data1, const char* irrep_str2, float* data2, const char* irrep_stro, float* datao);
+void tensor_product_v1(const Irreps* irreps_1, float* data_1, const Irreps* irreps_2, float* data_2, const Irreps* irreps_o, float* data_o);
 
 // tensor product between data1 and data2, written to datao, with respective
 // representation strings irrep_str1, irrep_str2, irrep_stro
 // uses sparse Clebsch-Gordan for faster computation
-void tensor_product_v2(const char* irrep_str1, const float* data1, const char* irrep_str2, const float* data2, const char* irrep_stro, float* datao);
+void tensor_product_v2(const Irreps* irreps_1, float* data_1, const Irreps* irreps_2, float* data_2, const Irreps* irreps_o, float* data_o);
 
 // tensor product between data1 and data2, written to datao, with respective
 // representation strings irrep_str1, irrep_str2, irrep_stro
 // uses precomputed tensor products in tp.c
-void tensor_product_v3(const char* irrep_str1, const float* data1, const char* irrep_str2, const float* data2, const char* irrep_stro, float* datao);
+void tensor_product_v3(const Irreps* irreps_1, float* data_1, const Irreps* irreps_2, float* data_2, const Irreps* irreps_o, float* data_o);
 
 // Real spherical harmonics Y_lm(r) of vector (x, y, z) written to out
-void spherical_harmonics(const char* irrep_str, const float x, const float y, const float z, float* out);
+void spherical_harmonics(const Irreps* irreps, const float x, const float y, const float z, float* out);
 
 // Linear or self-interaction operation
 // it is assumed that weights are raveled into a single float*, stored in the order they appear in irreps_in
 // does not support unsimplified irreps
-void linear(const char* irreps_in, const float* input, const float* weight, const char* irreps_out, float* out);
+void linear(const Irreps* irreps_in, const float* input, const float* weight, const Irreps* irreps_out, float* out);
 
 #endif // ifndef INCLUDED_E3NN_H

--- a/example.c
+++ b/example.c
@@ -5,29 +5,44 @@
 int main(void){
 
     // tensor product
+    Irreps* irreps1 = irreps_create("2x0e + 1x1o");
     float input1[] = { 0, 1, 2, 3, 4 };
+    Irreps* irreps2 = irreps_create("1x0o + 1x2o");
     float input2[] = { 0, 1, 2, 3, 4, 5 };
+    Irreps* irreps_product = irreps_create("2x0o + 2x1e + 1x2e + 2x2o + 1x3e");
     float product[30] = { 0 };
-    tensor_product("2x0e + 1x1o", input1, 
-                   "1x0o + 1x2o", input2, 
-                   "2x0o + 2x1e + 1x2e + 2x2o + 1x3e", product);
+    tensor_product(irreps1, input1, 
+                   irreps2, input2, 
+                   irreps_product, product);
 
     printf("product ["); for (int i = 0; i < 30; i++){ printf("%.2f, ", product[i]); } printf("]\n");
+    irreps_free(irreps1);
+    irreps_free(irreps2);
+    irreps_free(irreps_product);
+
 
     // spherical harmonics
+    Irreps* irreps_sph = irreps_create("1x0e + 1x1o + 1x2e");
     float sph[9] = { 0 };
-    spherical_harmonics("1x0e + 1x1o + 1x2e", 1.0, 2.0, 3.0, sph);
+    spherical_harmonics(irreps_sph, 1.0, 2.0, 3.0, sph);
 
     printf("sph ["); for (int i = 0; i < 9; i++) { printf("%.2f, ", sph[i]); } printf("]\n");
+    irreps_free(irreps_sph);
+
 
     // linear/self-interaction
+    Irreps* irreps3 = irreps_create("2x0e + 2x1o");
     float input3[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+    //                 [  2 x 3 weight  ][  2 x 3 weight  ]
     float weight[] = { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5 };
+    Irreps* irreps_output = irreps_create("3x0e + 3x1o");
     float output[12] = { 0 };
-    linear("2x0e + 2x1o", input3, weight,
-           "3x0e + 3x1o", output);
+    linear(irreps3, input3, weight,
+           irreps_output, output);
 
     printf("output ["); for (int i = 0; i < 12; i++) { printf("%.2f, ", output[i]); } printf("]\n");
-    
+    irreps_free(irreps3);
+    irreps_free(irreps_output);
+
     return 0;
 }

--- a/extra/benchmark_c_codegen.py
+++ b/extra/benchmark_c_codegen.py
@@ -26,29 +26,30 @@ for version in ["_v1", "_v2", "_v3"]:
         irrepso = e3nn.tensor_product(irreps1, irreps2)
         print(f'''
         {{
+            Irreps* irreps1 = irreps_create("{irreps1}");
+            Irreps* irreps2 = irreps_create("{irreps2}");
+            Irreps* irrepso = irreps_create("{irrepso}");
             float input1[{irreps1.dim}] = {{ 0 }};
             float input2[{irreps2.dim}] = {{ 0 }};
             float output[{irrepso.dim}] = {{ 0 }};
 
             // do once to build Clebsch-Gordan cache if necessary
-            tensor_product{version}("{irreps1}", 
-                        input1,
-                        "{irreps2}", 
-                        input2,
-                        "{irrepso}",
-                        output);
+            tensor_product{version}(irreps1, input1,
+                                    irreps2, input2,
+                                    irrepso, output);
 
             clock_t start = clock(); 
             for (int trial = 0; trial < {trials}; trial++) {{
-                tensor_product{version}("{irreps1}", 
-                            input1,
-                            "{irreps2}", 
-                            input2,
-                            "{irrepso}",
-                            output);
+                tensor_product{version}(irreps1, input1,
+                                        irreps2, input2,
+                                        irrepso, output);
             }}
             float elapsed = ((float) clock() - start) / CLOCKS_PER_SEC; 
             printf("{lmax}, %f\\n", elapsed); 
+
+            irreps_free(irreps1);
+            irreps_free(irreps2);
+            irreps_free(irrepso);
         }}
     ''')
 


### PR DESCRIPTION
E.g. Instead of:

```c
    float input1[] = { 0, 1, 2, 3, 4 };
    float input2[] = { 0, 1, 2, 3, 4, 5 };
    float product[30] = { 0 };
    tensor_product("2x0e + 1x1o", input1, 
                   "1x0o + 1x2o", input2, 
                   "2x0o + 2x1e + 1x2e + 2x2o + 1x3e", product);
```

Do

```c
    Irreps* irreps1 = irreps_create("2x0e + 1x1o");
    float input1[] = { 0, 1, 2, 3, 4 };
    Irreps* irreps2 = irreps_create("1x0o + 1x2o");
    float input2[] = { 0, 1, 2, 3, 4, 5 };
    Irreps* irreps_product = irreps_create("2x0o + 2x1e + 1x2e + 2x2o + 1x3e");
    float product[30] = { 0 };
    tensor_product(irreps1, input1, 
                   irreps2, input2, 
                   irreps_product, product);

    printf("product ["); for (int i = 0; i < 30; i++){ printf("%.2f, ", product[i]); } printf("]\n");
    irreps_free(irreps1);
    irreps_free(irreps2);
    irreps_free(irreps_product);
```

Made same change for linear, spherical_harmonics