### PR TITLE
Implement concat

### DIFF
--- a/e3nn.c
+++ b/e3nn.c
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
+#include <assert.h>
 
 #include "clebsch_gordan.h"
 #include "e3nn.h"
@@ -46,6 +48,25 @@ int irreps_dim(const Irreps* irreps) {
         dim += 2 * irreps->irreps[i].l + 1;
     }
     return dim;
+}
+
+
+bool irreps_is_sorted(const Irreps* irreps) {
+    if (irreps->size < 2) { return true; }
+    for (int i = 1; i < irreps->size; i++) {
+        Irrep curr = irreps->irreps[i];
+        Irrep prev = irreps->irreps[i-1];
+        if (prev.l > curr.l) {
+            return false;
+        }
+        if ((prev.l == curr.l) 
+            && ((prev.p == curr.p) 
+                || (prev.l % 2 == 0 && prev.p == ODD) 
+                || (prev.l % 2 == 1 && prev.p == EVEN))) {
+            return false;
+        }
+    }
+    return true;
 }
 
 
@@ -363,4 +384,11 @@ void linear(const Irreps* irreps_in, const float* input, const float* weight, co
         }
         in_ptr += (irreps_in->irreps[i_in].l * 2 + 1) * irreps_in->irreps[i_in].c;
     }
+}
+
+
+void concat(const Irreps* irreps_1, float* data_1, const Irreps* irreps_2, float* data_2, float* data_o) {
+    assert(irreps_is_sorted(irreps_1));
+    assert(irreps_is_sorted(irreps_2));
+    // TODO
 }

--- a/e3nn.c
+++ b/e3nn.c
@@ -42,10 +42,30 @@ void irreps_free(Irreps* irreps) {
 }
 
 
+int irrep_compare(const Irrep* i1, const Irrep* i2) {
+    if (i1->l == i2->l) {
+        if (i1->p == i2->p) {
+            return 0;
+        } else if (i1->l % 2 == 0 && i1->p == EVEN) {
+            return -1;
+        } else {
+            return 1;
+        }
+    } else {
+        return i1->l - i2->l;
+    }
+}
+
+
+int irrep_dim(const Irrep* irr) {
+    return irr->c * (2 * irr->l + 1);
+}
+
+
 int irreps_dim(const Irreps* irreps) {
     int dim = 0;
     for (int i = 0; i < irreps->size; i++) {
-        dim += 2 * irreps->irreps[i].l + 1;
+        dim += irrep_dim(&irreps->irreps[i]);
     }
     return dim;
 }
@@ -54,15 +74,7 @@ int irreps_dim(const Irreps* irreps) {
 bool irreps_is_sorted(const Irreps* irreps) {
     if (irreps->size < 2) { return true; }
     for (int i = 1; i < irreps->size; i++) {
-        Irrep curr = irreps->irreps[i];
-        Irrep prev = irreps->irreps[i-1];
-        if (prev.l > curr.l) {
-            return false;
-        }
-        if ((prev.l == curr.l) 
-            && ((prev.p == curr.p) 
-                || (prev.l % 2 == 0 && prev.p == ODD) 
-                || (prev.l % 2 == 1 && prev.p == EVEN))) {
+        if (irrep_compare(&irreps->irreps[i-1], &irreps->irreps[i]) >= 0) {
             return false;
         }
     }
@@ -387,8 +399,27 @@ void linear(const Irreps* irreps_in, const float* input, const float* weight, co
 }
 
 
-void concat(const Irreps* irreps_1, float* data_1, const Irreps* irreps_2, float* data_2, float* data_o) {
+void concatenate(const Irreps* irreps_1, float* data_1, const Irreps* irreps_2, float* data_2, float* data_o) {
     assert(irreps_is_sorted(irreps_1));
     assert(irreps_is_sorted(irreps_2));
-    // TODO
+    int inc_1 = 0, inc_2 = 0, inc_o = 0;
+    int i1 = 0, i2 = 0;
+    while (i1 < irreps_1->size || i2 < irreps_2->size) {
+        if (
+            (i1 < irreps_1->size) &&
+            (i2 >= irreps_2->size || irrep_compare(&irreps_1->irreps[i1], &irreps_2->irreps[i2]) <= 0)
+        ) {
+            int dim = irrep_dim(&irreps_1->irreps[i1]);
+            memcpy(data_o + inc_o, data_1 + inc_1, sizeof(float) * dim);
+            inc_1 += dim;
+            inc_o += dim;
+            i1++;
+        } else {
+            int dim = irrep_dim(&irreps_2->irreps[i2]);
+            memcpy(data_o + inc_o, data_2 + inc_2, sizeof(float) * dim);
+            inc_2 += dim;
+            inc_o += dim;
+            i2++;
+        }
+    }
 }

--- a/e3nn.h
+++ b/e3nn.h
@@ -45,9 +45,15 @@ void tensor_product_v3(const Irreps* irreps_1, float* data_1, const Irreps* irre
 // Real spherical harmonics Y_lm(r) of vector (x, y, z) written to out
 void spherical_harmonics(const Irreps* irreps, const float x, const float y, const float z, float* out);
 
-// Linear or self-interaction operation
+// linear or self-interaction operation
 // it is assumed that weights are raveled into a single float*, stored in the order they appear in irreps_in
-// does not support unsimplified irreps
+// NOTE: does not support unsimplified irreps
 void linear(const Irreps* irreps_in, const float* input, const float* weight, const Irreps* irreps_out, float* out);
+
+// concatenates irreps data together
+// NOTE: assumes inputs irreps are simplified and sorted, and will maintain
+// sorted order for output
+void concat(const Irreps* irreps_1, float* data_1, const Irreps* irreps_2,
+float* data_2, float* data_o);
 
 #endif // ifndef INCLUDED_E3NN_H

--- a/e3nn.h
+++ b/e3nn.h
@@ -53,6 +53,6 @@ void linear(const Irreps* irreps_in, const float* input, const float* weight, co
 // concatenates irreps data together
 // NOTE: assumes inputs irreps are simplified and sorted, and will maintain
 // sorted order for output
-void concat(const Irreps* irreps_1, float* data_1, const Irreps* irreps_2, float* data_2, float* data_o);
+void concatenate(const Irreps* irreps_1, float* data_1, const Irreps* irreps_2, float* data_2, float* data_o);
 
 #endif // ifndef INCLUDED_E3NN_H

--- a/e3nn.h
+++ b/e3nn.h
@@ -53,7 +53,6 @@ void linear(const Irreps* irreps_in, const float* input, const float* weight, co
 // concatenates irreps data together
 // NOTE: assumes inputs irreps are simplified and sorted, and will maintain
 // sorted order for output
-void concat(const Irreps* irreps_1, float* data_1, const Irreps* irreps_2,
-float* data_2, float* data_o);
+void concat(const Irreps* irreps_1, float* data_1, const Irreps* irreps_2, float* data_2, float* data_o);
 
 #endif // ifndef INCLUDED_E3NN_H


### PR DESCRIPTION
Concatenate data with irreps. Assumes inputs are sorted/simplified and will merge in sorted order. Doing so will avoid the need to implement regroup for the time being.