### PR TITLE
Irreps Ops

### DIFF
--- a/e3nn.c
+++ b/e3nn.c
@@ -126,7 +126,7 @@ Irreps* irreps_concatenate(const Irreps* irreps_1, const Irreps* irreps_2) {
             write_irr = irreps_2->irreps[i2++];
         }
 
-        if (irreps->size == 0 || irrep_compare(&write_irr, &irreps->irreps[irreps->size - 1])) {
+        if (irreps->size == 0 || irrep_compare(&write_irr, &irreps->irreps[irreps->size - 1]) > 0) {
             irreps->irreps[irreps->size] = write_irr;
             irreps->size += 1;
         } else {

--- a/e3nn.c
+++ b/e3nn.c
@@ -138,6 +138,30 @@ Irreps* irreps_concatenate(const Irreps* irreps_1, const Irreps* irreps_2) {
 }
 
 
+Irreps* irreps_linear(const Irreps* irreps_in, const Irreps* irreps_out, const bool force_irreps_out) {
+    Irreps* irreps = (Irreps*) malloc(sizeof(Irreps));
+    irreps->size = 0;
+    irreps->irreps = (Irrep*) malloc(irreps_out->size * sizeof(Irrep));
+
+    for (int i_out = 0; i_out < irreps_out->size; i_out++) {
+        if (force_irreps_out) {
+            irreps->irreps[irreps->size++] = irreps_out->irreps[i_out];
+            continue;
+        }
+        for (int i_in = 0; i_in < irreps_in->size; i_in++) {
+            if (irrep_compare(&irreps_in->irreps[i_in], &irreps_out->irreps[i_out]) == 0) {
+                irreps->irreps[irreps->size++] = irreps_out->irreps[i_out];
+                break;
+            }
+        }
+    }
+    if (!force_irreps_out) {
+        irreps->irreps = (Irrep*) realloc(irreps->irreps, irreps->size * sizeof(Irrep));
+    }
+    return irreps;
+}
+
+
 void irreps_free(Irreps* irreps) {
     free(irreps->irreps);
     free(irreps);

--- a/e3nn.c
+++ b/e3nn.c
@@ -36,6 +36,15 @@ Irreps* irreps_create(const char* str) {
 }
 
 
+Irreps* irreps_copy(const Irreps* irreps) {
+    Irreps* copy = (Irreps*) malloc(sizeof(Irreps));
+    copy->size = irreps->size;
+    copy->irreps = (Irrep*) malloc(copy->size * sizeof(Irrep));
+    memcpy(copy->irreps, irreps->irreps, copy->size * sizeof(Irrep));
+    return copy;
+}
+
+
 Irreps* irreps_tensor_product(const Irreps* irreps_1, const Irreps* irreps_2) {
     // Lookup table for channel count for each irrep in output
     // indexed by (l + (p+1)/2 * (L_MAX + 1))

--- a/e3nn.c
+++ b/e3nn.c
@@ -162,6 +162,19 @@ Irreps* irreps_linear(const Irreps* irreps_in, const Irreps* irreps_out, const b
 }
 
 
+int linear_weight_size(const Irreps* irreps_in, const Irreps* irreps_out) {
+    int size = 0;
+    for (int i_in = 0; i_in < irreps_in->size; i_in++) {
+        for (int i_out = 0; i_out < irreps_out->size; i_out++) {
+            if (irrep_compare(&irreps_in->irreps[i_in], &irreps_out->irreps[i_out]) == 0) {
+                size += irreps_in->irreps[i_in].c * irreps_out->irreps[i_out].c;
+            }
+        }
+    }
+    return size;
+}
+
+
 void irreps_free(Irreps* irreps) {
     free(irreps->irreps);
     free(irreps);

--- a/e3nn.h
+++ b/e3nn.h
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 #ifndef INCLUDED_E3NN_H
 #define INCLUDED_E3NN_H
 
@@ -27,6 +29,10 @@ Irreps* irreps_tensor_product(const Irreps*, const Irreps*);
 
 // create Irreps struct from concatenation of two Irreps
 Irreps* irreps_concatenate(const Irreps*, const Irreps*);
+
+// creates Irreps of the linear operation, removing unmatching Irreps if
+// force_irreps_out==false, but just copies output otherwise
+Irreps* irreps_linear(const Irreps* irreps_in, const Irreps* irreps_out, const bool force_irreps_out);
 
 // free Irreps struct
 void irreps_free(Irreps* irreps);

--- a/e3nn.h
+++ b/e3nn.h
@@ -22,11 +22,17 @@ typedef struct {
 // create Irreps struct from string
 Irreps* irreps_create(const char* str);
 
+// create Irreps struct from tensor product of two Irreps
+Irreps* irreps_tensor_product(const Irreps*, const Irreps*);
+
 // free Irreps struct
 void irreps_free(Irreps* irreps);
 
 // dimension of irreps
 int irreps_dim(const Irreps* irreps);
+
+// print out irreps
+void irreps_print(const Irreps* irreps);
 
 // tensor product between data1 and data2, written to datao, with respective
 // representation strings irrep_str1, irrep_str2, irrep_stro

--- a/e3nn.h
+++ b/e3nn.h
@@ -34,6 +34,9 @@ Irreps* irreps_concatenate(const Irreps*, const Irreps*);
 // force_irreps_out==false, but just copies output otherwise
 Irreps* irreps_linear(const Irreps* irreps_in, const Irreps* irreps_out, const bool force_irreps_out);
 
+// copies Irreps
+Irreps* irreps_copy(const Irreps*);
+
 // free Irreps struct
 void irreps_free(Irreps* irreps);
 

--- a/e3nn.h
+++ b/e3nn.h
@@ -25,6 +25,9 @@ Irreps* irreps_create(const char* str);
 // create Irreps struct from tensor product of two Irreps
 Irreps* irreps_tensor_product(const Irreps*, const Irreps*);
 
+// create Irreps struct from concatenation of two Irreps
+Irreps* irreps_concatenate(const Irreps*, const Irreps*);
+
 // free Irreps struct
 void irreps_free(Irreps* irreps);
 

--- a/e3nn.h
+++ b/e3nn.h
@@ -65,6 +65,10 @@ void spherical_harmonics(const Irreps* irreps, const float x, const float y, con
 // NOTE: does not support unsimplified irreps
 void linear(const Irreps* irreps_in, const float* input, const float* weight, const Irreps* irreps_out, float* out);
 
+// computes size of weights for linear operation
+int linear_weight_size(const Irreps* irreps_in, const Irreps* irreps_out);
+
+
 // concatenates irreps data together
 // NOTE: assumes inputs irreps are simplified and sorted, and will maintain
 // sorted order for output


### PR DESCRIPTION
Functions:

  - [X]  `Irreps* irreps_tensor_product(Irreps* i1, Irreps* i2)`: creates irreps of the tensor product between two irreps
  - [x] `Irreps* irreps_concatenate(Irreps* i1, Irreps* i2)`: creates irreps of the concatenation of two irreps
  - [x] `Irreps* irreps_linear(Irreps* input, Irreps* output, bool force_irreps_out)`: creates irreps of the linear operation **removing unmatching irreps if `force_irreps_out==false`, but just copies `output` otherwise**
  - [x] `int linear_weight_size(Irreps* input, Irreps* output)`: computes the weight matrix size given input and output irreps